### PR TITLE
support for windows paths

### DIFF
--- a/tests/collections/test_fs.py
+++ b/tests/collections/test_fs.py
@@ -36,6 +36,23 @@ def test__FSPath():
     assert "temp://a" == p.root
     assert "b" == p.relative_path
 
+    p = _FSPath("C:/temp")
+    assert "" == p.scheme
+    assert "C:/" == p.root
+    assert "temp" == p.relative_path
+
+    p = _FSPath("C:\\temp\\")    
+    assert "" == p.scheme
+    assert "C:/" == p.root
+    assert "temp" == p.relative_path
+
+    p = _FSPath("\\temp\\a\\b")    
+    assert "" == p.scheme
+    # Root will be default drive. No way of knowing during test
+    # assert "C:/" == p.root
+    assert "temp\\a\\b" == p.relative_path    
+
+
     raises(ValueError, lambda: _FSPath(None))
     raises(ValueError, lambda: _FSPath(""))
     raises(ValueError, lambda: _FSPath("a.txt"))

--- a/triad/collections/fs.py
+++ b/triad/collections/fs.py
@@ -82,7 +82,7 @@ class _FSPath(object):
             self._root = "/"
             if path[0].isupper():
                 self._root = os.path.splitdrive(path)[0] + self._root
-            self._path = os.path.splitdrive(path)[1].lstrip("/").lstrip("\\")
+            self._path = os.path.splitdrive(path)[1].strip("/").strip("\\")
         else:
             uri = urlparse(path)
             if uri.scheme == "" and not path.startswith("/"):

--- a/triad/collections/fs.py
+++ b/triad/collections/fs.py
@@ -76,6 +76,13 @@ class _FSPath(object):
             self._scheme = ""
             self._root = "/"
             self._path = os.path.abspath(path)
+        # Windows
+        if path[0].isupper() or "\\" in path:
+            self._scheme = ""
+            self._root = "/"
+            if path[0].isupper():
+                self._root = os.path.splitdrive(path)[0] + self._root
+            self._path = os.path.splitdrive(path)[1].lstrip("/").lstrip("\\")
         else:
             uri = urlparse(path)
             if uri.scheme == "" and not path.startswith("/"):


### PR DESCRIPTION
Note that there is an unexpected behavior in pyfilesystem. Just using the letter of the drive returns the current directory. A slash is needed after the drive to avoid this. This is why line 84 of fs.py looks like that. Line 85 is intended to strip both leading and training slashes from the relative path.

open_fs('C:')
OSFS('C:\\Users\\Kevin\\Desktop\\Projects')

open_fs('C:/')
OSFS('C:\\')

I am really unsure of this condition to check if the path starts with a capital letter. I think it should work, but I am unsure about any side effects this could cause with other file systems.
