### PR TITLE
windows support for _FSPath

### DIFF
--- a/tests/collections/test_fs.py
+++ b/tests/collections/test_fs.py
@@ -36,6 +36,22 @@ def test__FSPath():
     assert "temp://a" == p.root
     assert "b" == p.relative_path
 
+    # Windows test cases
+    p = _FSPath("c:\\folder\\myfile.txt")
+    assert "" == p.scheme
+    assert "c:/" == p.root
+    assert "folder/myfile.txt" == p.relative_path
+
+    p = _FSPath("\\\\tmp\\tmp.txt")
+    assert "" == p.scheme
+    assert "/" == p.root
+    assert "tmp/tmp.txt" == p.relative_path   
+
+    p = _FSPath("\\\\123.123.123.123\\share\\folder\\myfile.txt")
+    assert "" == p.scheme
+    assert "/" == p.root
+    assert "123.123.123.123/share/folder/myfile.txt" == p.relative_path 
+
     raises(ValueError, lambda: _FSPath(None))
     raises(ValueError, lambda: _FSPath(""))
     raises(ValueError, lambda: _FSPath("a.txt"))

--- a/tests/collections/test_fs.py
+++ b/tests/collections/test_fs.py
@@ -59,6 +59,14 @@ def test__FSPath():
 
 
 def test_fs(tmpdir):
+    # Tests to read and write with tmpdir without FS
+    tmpfile = os.path.join(tmpdir, "f.txt")
+    f = open(tmpfile, "a")
+    f.write("read test")
+    f.close()
+    f = open(tmpfile, "r")
+    assert f.read() == "read test"
+
     p1 = os.path.join(tmpdir, "a")
     p2 = os.path.join(tmpdir, "b")
     assert not os.path.exists(p1)

--- a/triad/collections/fs.py
+++ b/triad/collections/fs.py
@@ -15,16 +15,13 @@ class FileSystem(MountFS):
     for this class is that all paths must be absolute path with scheme.
     To customize different file systems, you should override `create_fs`
     to provide your own configured file systems.
-
     :Examples:
     >>> fs = FileSystem()
     >>> fs.writetext("mem://from/a.txt", "hello")
     >>> fs.copy("mem://from/a.txt", "mem://to/a.txt")
-
     :Notice:
     If a path is not a local path, it must include the scheme and `netloc`
     (the first element after `://`)
-
     :param auto_close: If `True` (the default), the child filesystems
       will be closed when `MountFS` is closed.
     """
@@ -38,10 +35,8 @@ class FileSystem(MountFS):
     def create_fs(self, root: str) -> FSBase:
         """create a PyFileSystem instance from `root`. `root` is in the
         format of `/` if local path, else `<scheme>://<netloc>`.
-
         You should override this method to provide custom instances, for
         example, if you want to create an S3FS with certain parameters.
-
         :param root: `/` if local path, else `<scheme>://<netloc>`
         """
         if root.startswith("temp://"):
@@ -62,7 +57,7 @@ class FileSystem(MountFS):
                 self._fs_store[fp.root] = self.create_fs(fp.root)
                 self.mount(to_uuid(fp.root), self._fs_store[fp.root])
             self._in_create = False
-        m_path = os.path.join(to_uuid(fp.root), fp.relative_path)
+        m_path = to_uuid(fp.root) + "/" + fp.relative_path
         return super()._delegate(m_path)
 
 


### PR DESCRIPTION
This PR is passing unit tests but failing Github Actions due to the GITHUB_TOKEN for coveralls. 

Please look at test_fs.py L#50-53. I am not 100% sure this unit test is designed correctly.

There are a couple of notes about seemingly inconsistent behavior across open_fs and PureWindowsPath.as_uri()

1. open_fs works weird on Windows. `open_fs('C:')` returns a file system on the current directory. `open_fs('C:/')` returns it on the root. Because of this, we need the trailing slash.

2. PureWindowsPath.as_uri() sometimes leaves a trailing slash and sometimes does not. This is why we need the rstrip function call. To test:
```python
print(PureWindowsPath("\\\\tmp\\tmp.txt").as_uri())     # Returns a trailing slash
print(PureWindowsPath("\\\\share\\folder\\myfile.txt").as_uri())
```

3. PureWindowsPath.as_uri() gives an extra slash if the path contains a drive like 'C:/test/tmp.txt'. To test this:
```python
print(PureWindowsPath("C:\\share\\folder\\myfile.txt").as_uri())
```
output: file:///C:/share/folder/myfile.txt
Note the third slash after 'file:'

