### PR TITLE
Add map type support to schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ pip install triad
 
 ## Release History
 
+### 0.6.8
+
+* Add map type support to Schema
+
 ### 0.6.7
 
 * Parse nested fields in `expression_to_schema` util

--- a/tests/collections/test_schema.py
+++ b/tests/collections/test_schema.py
@@ -25,6 +25,7 @@ def test_schema_init():
         == "a:long,b:str,c:int,d:datetime,e:str"
     )
     assert Schema(" a:{x:int32, y:str},b:[datetime]") == "a:{x:int,y:str},b:[datetime]"
+    assert Schema(" a:< str, int >,b:[datetime]") == "a:<str,int>,b:[datetime]"
     pa_schema = pa.schema([pa.field("123", pa.int32()), pa.field("b", pa.string())])
     raises(SchemaError, lambda: Schema(pa_schema))
     raises(SchemaError, lambda: Schema("a:int", b=str))
@@ -301,6 +302,10 @@ def test_schema_transform():
     assert s.transform("*,d:str ~ c,,a,x ") == "b:str,d:str"
     assert s.transform("*,d:str ~ c-a~x") == "b:str,d:str"
     assert s.transform("* + e:int,b:int,d:str") == "a:int,b:int,c:bool,e:int,d:str"
+    assert (
+        s.transform("*,d:[int],e:{b:str},f:<str,int>")
+        == "a:int,b:str,c:bool,d:[int],e:{b:str},f:<str,int>"
+    )
     # multiple operations will be applied in order
     assert s.transform("*+e:int,b:int-c~x,c") == "a:int,b:int,e:int"
     assert s.transform("* + - ~ ") == s  # no op

--- a/tests/utils/test_pyarrow_convert.py
+++ b/tests/utils/test_pyarrow_convert.py
@@ -112,8 +112,8 @@ def test_convert_to_binary():
     pdt = pd.Timestamp("2020-01-01T02:03:04")
 
     _test_convert(None, "bytes", None)
-    _test_convert(b'\x0e\x15', "bytes", b'\x0e\x15')
-    _test_convert(bytearray(b'\x0e\x15'), "bytes", b'\x0e\x15')
+    _test_convert(b"\x0e\x15", "bytes", b"\x0e\x15")
+    _test_convert(bytearray(b"\x0e\x15"), "bytes", b"\x0e\x15")
     _test_convert(False, "bytes", pickle.dumps(False))
     _test_convert("true", "bytes", pickle.dumps("true"))
     _test_convert(pd.NaT, "bytes", pickle.dumps(pd.NaT))
@@ -190,7 +190,7 @@ def test_convert_to_list_shallow():
     _assert_raise(pd.NaT, "[int]")
     _assert_raise(FLOAT_NAN, "[int]")
     _assert_raise(True, "[int]")
-    _assert_raise(np.ndarray([1,2]), "[int]", [1,2])
+    _assert_raise(np.ndarray([1, 2]), "[int]", [1, 2])
 
 
 def test_convert_to_list_deep():
@@ -204,6 +204,28 @@ def test_convert_to_list_deep():
     _test_convert_nested([d], "[[int]]", [[1]])
     _assert_raise(["x"], "[int]", True)
     _assert_raise(1, "[int]", True)
+
+
+def test_convert_to_map_shallow():
+    d = {"a": 1}
+    _test_convert(None, "<str,int>", None)
+    _test_convert(d, "<str,int>", d)
+    _test_convert({}, "<str,int>", {})
+    _assert_raise("1", "<str,int>")
+    _assert_raise("abc", "<str,int>")
+    _assert_raise(pd.NaT, "<str,int>")
+    _assert_raise(FLOAT_NAN, "<str,int>")
+    _assert_raise(True, "<str,int>")
+    _assert_raise(np.ndarray([1, 2]), "<str,int>")
+
+
+def test_convert_to_map_deep():
+    d = {"a": "1"}
+    _test_convert_nested(None, "<str,int>", None)
+    _test_convert_nested(d, "<str,int>", {"a": 1})
+    _test_convert_nested('{"a":{"b":"1"}}', "<str,<str,int>>", {"a": {"b": 1}})
+    _assert_raise({"a": "x"}, "<str,int>", True)
+    _assert_raise(1, "<str,int>", True)
 
 
 def _test_convert(orig, expected_type, expected_value):

--- a/tests/utils/test_pyarrow_convert.py
+++ b/tests/utils/test_pyarrow_convert.py
@@ -207,9 +207,9 @@ def test_convert_to_list_deep():
 
 
 def test_convert_to_map_shallow():
-    d = {"a": 1}
     _test_convert(None, "<str,int>", None)
-    _test_convert(d, "<str,int>", d)
+    _test_convert({"a": 1}, "<str,int>", {"a": 1})
+    _test_convert([("a", 1)], "<str,int>", [("a", 1)])
     _test_convert({}, "<str,int>", {})
     _assert_raise("1", "<str,int>")
     _assert_raise("abc", "<str,int>")
@@ -220,10 +220,10 @@ def test_convert_to_map_shallow():
 
 
 def test_convert_to_map_deep():
-    d = {"a": "1"}
     _test_convert_nested(None, "<str,int>", None)
-    _test_convert_nested(d, "<str,int>", {"a": 1})
-    _test_convert_nested('{"a":{"b":"1"}}', "<str,<str,int>>", {"a": {"b": 1}})
+    _test_convert_nested({"a": "1", "b": 1}, "<str,int>", [("a", 1), ("b", 1)])
+    _test_convert_nested([("a", "1")], "<str,int>", [("a", 1)])
+    _test_convert_nested('{"a":{"b":"1"}}', "<str,<str,int>>", [("a", [("b", 1)])])
     _assert_raise({"a": "x"}, "<str,int>", True)
     _assert_raise(1, "<str,int>", True)
 

--- a/triad/utils/pyarrow.py
+++ b/triad/utils/pyarrow.py
@@ -598,9 +598,11 @@ def _to_pymap(
         return None
     if isinstance(obj, str) and str_as_json:
         obj = json.loads(obj)
-    if not isinstance(obj, Dict):
-        raise TypeError(f"{obj} is not dict")
-    return {key_f(k): value_f(v) for k, v in obj.items()}
+    if isinstance(obj, Dict):
+        return [(key_f(k), value_f(v)) for k, v in obj.items()]
+    if isinstance(obj, list):
+        return [(key_f(k), value_f(v)) for k, v in obj]
+    raise NotImplementedError(f"{obj} can't be converted to map")
 
 
 def _no_op_convert(obj: Any) -> Any:  # pragma: no cover

--- a/triad/utils/pyarrow.py
+++ b/triad/utils/pyarrow.py
@@ -548,7 +548,7 @@ def _to_pybytes(obj: Any) -> Any:
     return pickle.dumps(obj)
 
 
-def _assert_pytype(pytype: type, obj: Any) -> Any:
+def _assert_pytype(pytype: Any, obj: Any) -> Any:
     if obj is None or isinstance(obj, pytype):
         return obj
     raise TypeError(f"{obj} is not {pytype}")
@@ -677,7 +677,7 @@ class _TypeConverter(object):
                 return lambda x: _to_pylist(converter, x, self._copy, self._str_as_json)
         elif pa.types.is_map(tp):
             if not self._deep:
-                return lambda x: _assert_pytype(dict, x)
+                return lambda x: _assert_pytype((dict, list), x)
             else:
                 k = self._build_type_converter(tp.key_type)
                 v = self._build_type_converter(tp.item_type)

--- a/triad_version/__init__.py
+++ b/triad_version/__init__.py
@@ -1,2 +1,2 @@
 # flake8: noqa
-__version__ = "0.6.7"
+__version__ = "0.6.8"


### PR DESCRIPTION
This PR enables map type support, for example

```
a:<str,int>,b:int,c:{x:int}
```