### PR TITLE
Add `numpy` to package requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
     keywords="fugue util utils utility utilities",
     url="http://github.com/fugue-project/triad",
     install_requires=[
+        "numpy",
         "pandas",
         "six",
         "pyarrow",


### PR DESCRIPTION
Based on the dependency analysis in https://github.com/conda-forge/triad-feedstock/pull/21, seems like it would make sense to add `numpy` to the package requirements.